### PR TITLE
Update CSRF_TRUSTED_ORIGINS for local deployment

### DIFF
--- a/localca_project/localca_project/settings.py
+++ b/localca_project/localca_project/settings.py
@@ -145,9 +145,9 @@ LOGOUT_REDIRECT_URL = 'homepage'  # Where to redirect after logout
 LOGIN_URL = 'login'  # Where to redirect if login is required
 #CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS').split(",")
 
-#This change below will prevent the local deploys from breaking and set the default variable to localhost. 
+#This change below will prevent the local deploys from breaking and set the default variable to localhost.
 #But user must not forget to set their own correct envirnment variables
-CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS') 
+CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS')
 if not CSRF_TRUSTED_ORIGINS:
     if DEBUG:
         CSRF_TRUSTED_ORIGINS = ['localhost']


### PR DESCRIPTION
Ensure CSRF_TRUSTED_ORIGINS defaults to localhost for local deployments.